### PR TITLE
chore(workflows): remove release steps from build workflows

### DIFF
--- a/.github/workflows/build-all.yml
+++ b/.github/workflows/build-all.yml
@@ -8,43 +8,45 @@ on:
 jobs:
   build-macos:
     uses: ./.github/workflows/build-macos.yml
-    
+
   build-linux:
     uses: ./.github/workflows/build-linux.yml
-    
+
   build-windows:
     uses: ./.github/workflows/build-windows.yml
-    
+
   create-release:
     needs: [build-macos, build-linux, build-windows]
     runs-on: ubuntu-latest
     if: startsWith(github.ref, 'refs/tags/')
-    
+    permissions:
+      contents: write
+
     steps:
     - name: Download all artifacts
       uses: actions/download-artifact@v4
       with:
         path: artifacts
-        
+
     - name: Create Release
       uses: softprops/action-gh-release@v2
       with:
         name: Py-Fusion ${{ github.ref_name }}
         body: |
           # Py-Fusion ${{ github.ref_name }}
-          
+
           A modern tool for merging multiple folders intelligently.
-          
+
           ## Downloads
-          
+
           ### macOS
           - [CLI Version](https://github.com/mateoltd/py-fusion/releases/download/${{ github.ref_name }}/py-fusion-cli-macos)
           - [GUI Version (DMG)](https://github.com/mateoltd/py-fusion/releases/download/${{ github.ref_name }}/Py-Fusion.dmg)
-          
+
           ### Linux
           - [CLI Version (tar.gz)](https://github.com/mateoltd/py-fusion/releases/download/${{ github.ref_name }}/py-fusion-cli-linux.tar.gz)
           - [GUI Version (AppImage)](https://github.com/mateoltd/py-fusion/releases/download/${{ github.ref_name }}/Py-Fusion-x86_64.AppImage)
-          
+
           ### Windows
           - [CLI Version (ZIP)](https://github.com/mateoltd/py-fusion/releases/download/${{ github.ref_name }}/py-fusion-cli-windows.zip)
           - [GUI Version (Installer)](https://github.com/mateoltd/py-fusion/releases/download/${{ github.ref_name }}/Py-Fusion-Setup.exe)

--- a/.github/workflows/build-linux.yml
+++ b/.github/workflows/build-linux.yml
@@ -118,13 +118,3 @@ jobs:
       with:
         name: py-fusion-gui-linux
         path: dist/Py-Fusion-x86_64.AppImage
-
-    - name: Create Release
-      uses: softprops/action-gh-release@v2
-      if: startsWith(github.ref, 'refs/tags/')
-      with:
-        files: |
-          dist/py-fusion-cli-linux.tar.gz
-          dist/Py-Fusion-x86_64.AppImage
-      env:
-        GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/build-macos.yml
+++ b/.github/workflows/build-macos.yml
@@ -11,7 +11,7 @@ on:
 jobs:
   build-macos:
     runs-on: macos-latest
-    
+
     steps:
     - uses: actions/checkout@v4
 
@@ -19,51 +19,41 @@ jobs:
       uses: actions/setup-python@v5
       with:
         python-version: '3.9'
-        
+
     - name: Install dependencies
       run: |
         python -m pip install --upgrade pip
         pip install -r requirements.txt
         pip install pyinstaller
-        
+
     - name: Build CLI version
       run: |
         pyinstaller --name py-fusion --onefile index.py
-        
+
     - name: Build GUI version
       run: |
         pyinstaller --name py-fusion-gui --onefile --windowed --icon=py_fusion_gui/resources/icons/py_fusion.icns run_py_fusion_gui.py
-        
+
     - name: Create DMG for GUI version
       run: |
         # Create a directory for the app
         mkdir -p dist/dmg
         cp -r "dist/py-fusion-gui.app" dist/dmg/
-        
+
         # Create a symbolic link to /Applications
         ln -s /Applications dist/dmg/
-        
+
         # Create the DMG
         hdiutil create -volname "Py-Fusion" -srcfolder dist/dmg -ov -format UDZO dist/Py-Fusion.dmg
-        
+
     - name: Upload CLI artifact
       uses: actions/upload-artifact@v4
       with:
         name: py-fusion-cli-macos
         path: dist/py-fusion
-        
+
     - name: Upload GUI artifact
       uses: actions/upload-artifact@v4
       with:
         name: py-fusion-gui-macos
         path: dist/Py-Fusion.dmg
-        
-    - name: Create Release
-      uses: softprops/action-gh-release@v2
-      if: startsWith(github.ref, 'refs/tags/')
-      with:
-        files: |
-          dist/py-fusion
-          dist/Py-Fusion.dmg
-      env:
-        GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/build-windows.yml
+++ b/.github/workflows/build-windows.yml
@@ -109,13 +109,3 @@ jobs:
       with:
         name: py-fusion-gui-windows
         path: dist/Py-Fusion-Setup.exe
-
-    - name: Create Release
-      uses: softprops/action-gh-release@v2
-      if: startsWith(github.ref, 'refs/tags/')
-      with:
-        files: |
-          dist/py-fusion-cli-windows.zip
-          dist/Py-Fusion-Setup.exe
-      env:
-        GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}


### PR DESCRIPTION
This PR centralizes GitHub release creation and eliminates the previous race condition across workflows:

- Remove all release-creation steps from the individual platform workflows.	
- Keep only the centralized release-creation job in build-all.yml.
- Add explicit permissions to the create-release job in build-all.yml (contents: write) so it can create and update releases.

Now, only one workflow is responsible for creating the release, and it has the correct permissions to do so.